### PR TITLE
added descriptions for elements

### DIFF
--- a/ceci.js
+++ b/ceci.js
@@ -201,6 +201,9 @@ define(function() {
     if (def.template){
       element.innerHTML = def.template.innerHTML;
     }
+    if (def.description) {
+      element.description = def.description;
+    }
 
     def.contructor.call(element, def.initParams | {});
 
@@ -214,6 +217,7 @@ define(function() {
     var name = element.getAttribute('name');
     var template = element.querySelector('template');
     var script = element.querySelector('script[type="text/ceci"]');
+    var description = element.querySelector('description');
 
     try{
       var generator = new Function("Ceci", "return function() {" + script.innerHTML+ "}");
@@ -231,7 +235,8 @@ define(function() {
 
     Ceci._components[name] = {
       template: template,
-      contructor: contructor
+      contructor: contructor,
+      description: description
     };
 
     var existingElements = document.querySelectorAll(name);
@@ -240,16 +245,16 @@ define(function() {
     });
   };
 
-  Ceci.load = function (callback) {
-    function scrape (callback) {
-      var elements = document.querySelectorAll('element');
-      elements = Array.prototype.slice.call(elements);
-      elements.forEach(Ceci.processComponent);
-      if (callback){
-        callback(Ceci._components);
-      }
+  function scrape (callOnComplete) {
+    var elements = document.querySelectorAll('element');
+    elements = Array.prototype.slice.call(elements);
+    elements.forEach(Ceci.processComponent);
+    if (callOnComplete){
+      callOnComplete(Ceci._components);
     }
+  }
 
+  Ceci.load = function (callOnComplete) {
     var ceciLinks = document.querySelectorAll('link[rel=component][type="text/ceci"]');
 
     if (ceciLinks.length) {
@@ -260,6 +265,7 @@ define(function() {
         xhr.open('GET', docURL ,true);
         xhr.onload = function (e) {
           var fragment = document.createElement('div');
+          fragment.setAttribute("style","display:none!important");
           fragment.innerHTML = xhr.response;
           if (document.body.firstChild) {
             document.body.insertBefore(fragment, document.body.firstChild);
@@ -268,14 +274,14 @@ define(function() {
             document.body.appendChild(fragment);
           }
           if (--linksLeft === 0) {
-            scrape(callback);
+            scrape(callOnComplete);
           }
         };
         xhr.send(null);
       });
     }
     else {
-      scrape(callback);
+      scrape(callOnComplete);
     }
   };
 

--- a/components.html
+++ b/components.html
@@ -53,3 +53,27 @@
     });
   </script>
 </element>
+
+<element name="app-test-documentation">
+  <template>
+    <p class="content">Just some text</p>
+  </template>
+  <description>
+    <h1>The <code>app-pomax</code> element</h1>
+    <p>This element can be used to test Ceci.js functionality.</p>
+    <p>We can use arbitrary documentation here, although it might make
+      sense to use some established microdata format for semantic
+      tagging of information.</p>
+  </description>
+  <script type="text/ceci">
+    Ceci(this, {
+      init: function (params) {
+      },
+      listeners: {
+        setText: function (val) {
+          this.querySelector('.content').innerHTML = val;
+        }
+      }
+    });
+  </script>
+</element>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <link rel="component" type="text/ceci" href="//appmaker-components.herokuapp.com/package/all">
+    <link rel="component" type="text/ceci" href="components.html">
   </head>
   <body>
     <app-counter id="counter">
@@ -25,6 +26,8 @@
     <app-counter id="counter-green">
       <listen on="green" for="increase">
     </app-counter>
+
+    <app-test-documentation id="test-docs">
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.8/require.min.js"></script>
     <script>


### PR DESCRIPTION
In addition to the `template` and `script` block, custom elements can now also take a `description` block that lets you stick in arbitrary HTML as a description for how this element works.
