### PR TITLE
Enabling extending

### DIFF
--- a/ceci-app.js
+++ b/ceci-app.js
@@ -100,7 +100,7 @@ define(["jquery", "ceci", "ceci-cards", "ceci-ui", "jquery-ui"], function($, Cec
 
   App.addLoadListener = function(listener) {
     loadlisteners.push(listener);
-  }
+  };
 
   App.getUuid = getUuid;
 

--- a/ceci-app.js
+++ b/ceci-app.js
@@ -39,7 +39,9 @@ define(["jquery", "ceci", "ceci-cards", "ceci-ui", "jquery-ui"], function($, Cec
     });
   }
 
-  var App = function(params){
+  var loadlisteners = [];
+
+  var App = function(params) {
 
     this.componentAddedCallback = typeof params.onComponentAdded === 'function' ? params.onComponentAdded : function(){};
 
@@ -81,6 +83,10 @@ define(["jquery", "ceci", "ceci-cards", "ceci-ui", "jquery-ui"], function($, Cec
         if (typeof params.onload === 'function'){
           params.onload(components);
         }
+
+        loadlisteners.forEach(function(listener) {
+          listener(components);
+        });
       });
     };
 
@@ -91,6 +97,10 @@ define(["jquery", "ceci", "ceci-cards", "ceci-ui", "jquery-ui"], function($, Cec
       getUuid(this, init);
     }
   };
+
+  App.addLoadListener = function(listener) {
+    loadlisteners.push(listener);
+  }
 
   App.getUuid = getUuid;
 

--- a/ceci.js
+++ b/ceci.js
@@ -309,7 +309,9 @@ define(function() {
       setupBroadcastLogic(instance, originalElement);
       setupSubscriptionLogic(instance, originalElement);
       instance.init();
-      completedHandler(instance);
+      if(completedHandler) {
+        completedHandler(instance);
+      }
     };
     finalize.called = false;
 


### PR DESCRIPTION
added a way to add your own loadlisteners to App (from ceci-app) and squashed a bug in Ceci where it called a callback even if it wasn't defined.
