### PR TITLE
added endpoint property

### DIFF
--- a/ceci.js
+++ b/ceci.js
@@ -48,7 +48,12 @@ define(function() {
       });
     }
 
+    if(buildProperties.endpoint) {
+      element.endpoint = true;
+    }
+
     element.emit = function (data) {
+      if(element.endpoint) return;
       if(element.broadcastChannel === Ceci.emptyChannel) return;
       var e = new CustomEvent(element.broadcastChannel, {bubbles: true, detail: data});
       element.dispatchEvent(e);


### PR DESCRIPTION
added the  ".endpoint" property for elements that should not be able to broadcast at all, in a way that can (by turning it to false) be overridden if we really, really need to at runtime. 
